### PR TITLE
feat(CI): add docker build and publish action

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,0 +1,46 @@
+name: Create and publish the Docker image
+
+on:
+  push:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # on tag, tag the tag :)
+            type=ref,event=tag
+            # latest based on default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            # prefix for development
+            type=sha,prefix={{branch}}-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN go mod download
 
 # Copy the go source
 COPY cmd/main.go cmd/main.go
-#COPY api/ api/
-COPY internal/controller/ internal/controller/
+COPY apis/ apis/
+COPY internal/ internal/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command


### PR DESCRIPTION
The most interesting part from this PR is probably this:

```
# on tag, tag the tag :)
type=ref,event=tag
# latest based on default branch
type=raw,value=latest,enable={{is_default_branch}}
# prefix for development
type=sha,prefix={{branch}}-
```

Basically, this means:
- `ghcr.io/oskoperator/osko:<tag>` on any tag (maybe we should limit it to default branch only? although honestly, I wouldn't...
- `ghcr.io/oskoperator/osko:latest` for latest commit in the default branch
- `ghcr.io/oskoperator/osko:docker-image-build-febdd99` on the latest commit in this branch, for example (built every time)