### PR TITLE
feat(controller): time-based mimirrule reconcile

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,7 +54,7 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 
 	var mimirRuleRequeuePeriod time.Duration
-	mimirRuleRequeuePeriodDefault, err := time.ParseDuration("5m")
+	mimirRuleRequeuePeriodDefault, err := time.ParseDuration("1m")
 	if err != nil {
 		setupLog.Error(err, "can't parse default \"mimirRuleRequeuePeriodDefault\"")
 		os.Exit(1)

--- a/config/crd/bases/openslo.com_slos.yaml
+++ b/config/crd/bases/openslo.com_slos.yaml
@@ -469,8 +469,7 @@ spec:
               conditions:
                 description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerate code after modifying
-                  this file TODO: Maybe we should use something like []corev1.ObejctReference
-                  here?'
+                  this file'
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct

--- a/internal/controller/osko/mimirrule_controller.go
+++ b/internal/controller/osko/mimirrule_controller.go
@@ -92,7 +92,6 @@ func (r *MimirRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 		}
 		return ctrl.Result{}, nil
-
 	}
 
 	if apierrors.IsNotFound(err) {
@@ -241,37 +240,11 @@ func (r *MimirRuleReconciler) createMimirRuleGroupAPI(log logr.Logger, rule *osk
 	return nil
 }
 
-func (r *MimirRuleReconciler) getMimirRuleGroupAPI(log logr.Logger, rule *monitoringv1.PrometheusRule) *rwrulefmt.RuleGroup {
-	mimirRuleGroup, err := r.MimirClient.GetRuleGroup(context.Background(), mimirRuleNamespace, rule.Name)
-	if err != nil {
-		log.Error(err, "Failed to get rule group")
-		return nil
-	}
-
-	return mimirRuleGroup
-}
-
-//func (r *MimirRuleReconciler) createMimirRuleGroup(log logr.Logger, mimirClient *mimirclient.MimirClient, rule *monitoringv1.PrometheusRule, ds *openslov1.Datasource) error {
-//	mimirRuleGroup, err := helpers.NewMimirRuleGroup(rule)
-//	if err != nil {
-//		log.Error(err, "Failed to create Mimir rule group")
-//		return err
-//	}
-//
-//	if err := mimirClient.CreateRuleGroup(context.Background(), mimirRuleNamespace, *mimirRuleGroup); err != nil {
-//		log.Error(err, "Failed to create rule group")
-//		return err
-//	}
-//
-//	return nil
-//}
-
 func (r *MimirRuleReconciler) deleteMimirRuleGroupAPI(log logr.Logger, name string) error {
 	if err := r.MimirClient.DeleteRuleGroup(context.Background(), mimirRuleNamespace, name); err != nil {
 		log.Error(err, "Failed to delete rule group")
 		return err
 	}
-
 	return nil
 }
 

--- a/internal/controller/osko/mimirrule_controller.go
+++ b/internal/controller/osko/mimirrule_controller.go
@@ -154,7 +154,7 @@ func (r *MimirRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if !controllerutil.ContainsFinalizer(mimirRule, mimirRuleFinalizer) {
 		controllerutil.AddFinalizer(mimirRule, mimirRuleFinalizer)
 		if err := r.Update(ctx, mimirRule); err != nil {
-			log.Error(err, "Failed to remove the finalizer from the MimirRule")
+			log.Error(err, "Failed to add the finalizer to the MimirRule")
 			return ctrl.Result{}, err
 		}
 	}
@@ -237,8 +237,6 @@ func (r *MimirRuleReconciler) createMimirRuleGroupAPI(log logr.Logger, rule *osk
 		log.Error(err, "Failed to create rule group")
 		return err
 	}
-
-	// TODO: move finalizer addition here
 
 	return nil
 }


### PR DESCRIPTION
the motivation here is to check what the status in the mimirrule API is on schedule and act based on the difference between the state in the Mimir (or potentially Cortex) API compared to what our `osko` sees in Kubernetes