### PR TITLE
chore: add release-drafter gh action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,90 @@
+category-template: '## $TITLE'
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+tag-prefix: ''
+version-template: $MAJOR.$MINOR.$PATCH
+change-template: '* $TITLE (#$NUMBER) by @$AUTHOR'
+change-title-escapes: ''
+no-changes-template: 'No changes were made in this version. Stay tuned for upcoming updates!'
+categories:
+  - title: '⚡ Breaking Changes'
+    labels:
+      - 'breaking-change'
+  - title: '🌟 New Features'
+    labels:
+      - 'feature'
+  - title: '🔧 Improvements'
+    labels:
+      - 'enhancement'
+  - title: '📜 Documentation Updates'
+    labels:
+      - 'documentation'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '🚒 Deprecations'
+    labels:
+      - 'deprecation'
+  - title: '🔧 Maintenance'
+    labels:
+      - 'chore'
+  - title: '📦 Dependency Updates'
+    collapse-after: 10
+    labels:
+      - 'dependencies'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+      - 'breaking-change'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+      - 'enhancement'
+      - 'deprecation'
+  patch:
+    labels:
+      - 'patch'
+      - 'documentation'
+      - 'bug'
+      - 'bugfix'
+      - 'fix'
+      - 'chore'
+      - 'internal'
+      - 'dependencies'
+  default: patch
+autolabeler:
+  - label: 'breaking-change'
+    title:
+      - '/.*!:.*/'
+  - label: 'feature'
+    title:
+      - '/feat.*: /i'
+  - label: 'bug'
+    title:
+      - '/fix.*: /i'
+      - '/bug.*: /i'
+  - label: 'dependencies'
+    branch:
+      - '/dependabot\/.*/'
+  - label: 'documentation'
+    files:
+      - '*.md'
+  - label: 'chore'
+    files:
+      - '*.md'
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  ## Summary
+
+  **[Human readable summary of changes]**
+
+  ## Changes
+
+  $CHANGES
+
+  ## This release was made possible by the following contributors:
+
+  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,41 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v6
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To improve the way releases are done, I want to start with the release content and fill it with the content of the PRs made since the last release.

For that, I'll use https://github.com/marketplace/actions/release-drafter action, and on the next PRs I'll try to fill a CONTRIBUTING.md document and at the same time I'll think about #131 in order to not only fill the release document, but also make a proper release (update project versions, and so on)


Related to #125 