### PR TITLE
ci: add test and helm lint workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: make test
+
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+
+      - name: Add Prometheus Helm repository
+        run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+
+      - name: Build Helm dependencies
+        run: helm dependency build helm/osko
+
+      - name: Lint Helm chart
+        run: helm lint helm/osko
+
+      - name: Template Helm chart
+        run: helm template osko helm/osko


### PR DESCRIPTION
## Summary

- Add CI workflow that runs on PRs and main push
- **test** job: runs `make test` (Go unit tests with envtest)
- **helm-lint** job: runs `helm lint` + `helm template` on the osko chart

Ensures code and chart quality is verified before merge — currently no CI test coverage exists.